### PR TITLE
Replace Buffer with Uint8Array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,20 +11,20 @@ export interface IGetToken<T> {
 
   /**
    * Decode value from buffer at offset
-   * @param buffer - Buffer to read the decoded value from
+   * @param array - Uint8Array to read the decoded value from
    * @param offset - Decode offset
    * @return decoded value
    */
-  get(buffer: Buffer, offset: number): T;
+  get(array: Uint8Array, offset: number): T;
 }
 
 export interface IToken<T> extends IGetToken<T> {
   /**
    * Encode value to buffer
-   * @param buffer - Buffer to write the encoded value to
+   * @param array - Uint8Array to write the encoded value to
    * @param offset - Buffer write offset
    * @param value - Value to decode of type T
    * @return offset plus number of bytes written
    */
-  put(buffer: Buffer, offset: number, value: T): number
+  put(array: Uint8Array, offset: number, value: T): number
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenizer/token",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "TypeScript definition for strtok3 token",
   "main": "",
   "types": "index.d.ts",


### PR DESCRIPTION
Implements Borewit/tokenizer-token#2

For better cross JavaScript (Node.js & browser) replace [Buffer](https://nodejs.org/api/buffer.html) with [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array).