### PR TITLE
Ability to override Uint8Array with a inherited type e.g. Buffer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
  * Read-only token
  * See https://github.com/Borewit/strtok3 for more information
  */
-export interface IGetToken<T> {
+export interface IGetToken<Value, Array extends Uint8Array = Uint8Array> {
 
   /**
    * Length of encoded token in bytes
@@ -15,10 +15,10 @@ export interface IGetToken<T> {
    * @param offset - Decode offset
    * @return decoded value
    */
-  get(array: Uint8Array, offset: number): T;
+  get(array: Array, offset: number): Value;
 }
 
-export interface IToken<T> extends IGetToken<T> {
+export interface IToken<Value, Array extends Uint8Array = Uint8Array> extends IGetToken<Value, Array> {
   /**
    * Encode value to buffer
    * @param array - Uint8Array to write the encoded value to
@@ -26,5 +26,5 @@ export interface IToken<T> extends IGetToken<T> {
    * @param value - Value to decode of type T
    * @return offset plus number of bytes written
    */
-  put(array: Uint8Array, offset: number, value: T): number
+  put(array: Array, offset: number, value: Value): number
 }


### PR DESCRIPTION
This offers better backwards compatibility then [v0.2.0](https://github.com/Borewit/tokenizer-token/releases/tag/v0.2.0) allowing by specifying `Buffer` for `Array`,, e.g.:  `IGetToken<T, Buffer>`

Related to:  Borewit/token-types#246, Borewit/strtok3#522